### PR TITLE
Update to latest conda version 4.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Currently Azure ML supports both cuda9 and cuda10 base images. The major depende
 
 | Dependencies | IntelMPI CPU | OpenMPI CPU | IntelMPI GPU | OpenMPI GPU |
 | --- | --- | --- | --- | --- |
-| miniconda | ==4.5.11 | ==4.5.11 | ==4.5.11 | ==4.5.11 |
+| miniconda | ==4.8.3 | ==4.8.3 | ==4.8.3 | ==4.8.3 |
 | mpi | intelmpi==2018.3.222 |openmpi==3.1.2 |intelmpi==2018.3.222| openmpi==3.1.2 |
 | cuda | - | - | 9.0/10.0 | 9.0/10.0/10.1 |
 | cudnn | - | - | 7.4/7.5 | 7.4/7.5 |

--- a/base/cpu/intelmpi2018.3-ubuntu16.04/Dockerfile
+++ b/base/cpu/intelmpi2018.3-ubuntu16.04/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Conda Environment
-ENV MINICONDA_VERSION 4.5.11
+ENV MINICONDA_VERSION 4.8.3
 ENV PATH /opt/miniconda/bin:$PATH
 RUN wget -qO /tmp/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash /tmp/miniconda.sh -bf -p /opt/miniconda && \

--- a/base/cpu/openmpi3.1.2-ubuntu16.04/Dockerfile
+++ b/base/cpu/openmpi3.1.2-ubuntu16.04/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Conda Environment
-ENV MINICONDA_VERSION 4.5.11
+ENV MINICONDA_VERSION 4.8.3
 ENV PATH /opt/miniconda/bin:$PATH
 RUN wget -qO /tmp/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash /tmp/miniconda.sh -bf -p /opt/miniconda && \

--- a/base/cpu/openmpi3.1.2-ubuntu18.04/Dockerfile
+++ b/base/cpu/openmpi3.1.2-ubuntu18.04/Dockerfile
@@ -54,7 +54,7 @@ ENV WORKER_TIMEOUT=300
 EXPOSE 5001 8883 8888
 
 # Conda Environment
-ENV MINICONDA_VERSION 4.5.11
+ENV MINICONDA_VERSION 4.8.3
 ENV PATH /opt/miniconda/bin:$PATH
 RUN wget -qO /tmp/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash /tmp/miniconda.sh -bf -p /opt/miniconda && \

--- a/base/gpu/intelmpi2018.3-cuda10.0-cudnn7-ubuntu16.04/Dockerfile
+++ b/base/gpu/intelmpi2018.3-cuda10.0-cudnn7-ubuntu16.04/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Conda Environment
-ENV MINICONDA_VERSION 4.5.11
+ENV MINICONDA_VERSION 4.8.3
 ENV PATH /opt/miniconda/bin:$PATH
 RUN wget -qO /tmp/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash /tmp/miniconda.sh -bf -p /opt/miniconda && \

--- a/base/gpu/intelmpi2018.3-cuda9.0-cudnn7-ubuntu16.04/Dockerfile
+++ b/base/gpu/intelmpi2018.3-cuda9.0-cudnn7-ubuntu16.04/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Conda Environment
-ENV MINICONDA_VERSION 4.5.11
+ENV MINICONDA_VERSION 4.8.3
 ENV PATH /opt/miniconda/bin:$PATH
 RUN wget -qO /tmp/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash /tmp/miniconda.sh -bf -p /opt/miniconda && \

--- a/base/gpu/openmpi3.1.2-cuda10.0-cudnn7-ubuntu16.04/Dockerfile
+++ b/base/gpu/openmpi3.1.2-cuda10.0-cudnn7-ubuntu16.04/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Conda Environment
-ENV MINICONDA_VERSION 4.5.11
+ENV MINICONDA_VERSION 4.8.3
 ENV PATH /opt/miniconda/bin:$PATH
 RUN wget -qO /tmp/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash /tmp/miniconda.sh -bf -p /opt/miniconda && \

--- a/base/gpu/openmpi3.1.2-cuda10.0-cudnn7-ubuntu18.04/Dockerfile
+++ b/base/gpu/openmpi3.1.2-cuda10.0-cudnn7-ubuntu18.04/Dockerfile
@@ -73,7 +73,7 @@ ENV WORKER_TIMEOUT=300
 EXPOSE 5001 8883 8888
 
 # Conda Environment
-ENV MINICONDA_VERSION 4.5.11
+ENV MINICONDA_VERSION 4.8.3
 ENV PATH /opt/miniconda/bin:$PATH
 RUN wget -qO /tmp/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash /tmp/miniconda.sh -bf -p /opt/miniconda && \

--- a/base/gpu/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04/Dockerfile
+++ b/base/gpu/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04/Dockerfile
@@ -70,7 +70,7 @@ ENV WORKER_TIMEOUT=300
 EXPOSE 5001 8883 8888
 
 # Conda Environment
-ENV MINICONDA_VERSION 4.5.11
+ENV MINICONDA_VERSION 4.8.3
 ENV PATH /opt/miniconda/bin:$PATH
 RUN wget -qO /tmp/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash /tmp/miniconda.sh -bf -p /opt/miniconda && \

--- a/base/gpu/openmpi3.1.2-cuda9.0-cudnn7-ubuntu16.04/Dockerfile
+++ b/base/gpu/openmpi3.1.2-cuda9.0-cudnn7-ubuntu16.04/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Conda Environment
-ENV MINICONDA_VERSION 4.5.11
+ENV MINICONDA_VERSION 4.8.3
 ENV PATH /opt/miniconda/bin:$PATH
 RUN wget -qO /tmp/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash /tmp/miniconda.sh -bf -p /opt/miniconda && \


### PR DESCRIPTION
In this pull-request I have updated miniconda-version to the latest released version.

**Why?**
For my AzureML Environment based on docker/conda I ran into installation issues comparable to:
[conda-issue-9761](https://github.com/conda/conda/issues/9761). Looks like a permission issue.

I have created my own dockerfile just adding the conda update. After this addition the installation went oke. I could not pin-point the version including the fix in the [long list of fixes in conda](https://github.com/conda/conda/blob/master/CHANGELOG.md#4511-2018-08-21).

I have only used the CPU (ubuntu16) based image.

**Reproducable problem detail:**

```python
from azureml.core import Workspace, Environment
from azureml.core.conda_dependencies import CondaDependencies

ws = Workspace.from_config()

env = Environment(name="shared_azml_py37")
env.docker.base_image = 'mcr.microsoft.com/azureml/base:intelmpi2018.3-ubuntu16.04' # = DEFAULT_CPU_IMAGE

dockerfile = r'''
FROM mcr.microsoft.com/azureml/base:intelmpi2018.3-ubuntu16.04
RUN conda update --name base --channel defaults conda --yes --quiet \
        && echo "CUSTOM: Using latest version: $(conda --version)"
'''
# Fix (uncommand next 2 lines)
#env.docker.base_image = None
#env.docker.base_dockerfile = dockerfile

env.python.conda_dependencies = CondaDependencies(conda_dependencies_file_path="conda_run_env.yml")
env.register(ws)

build = env.build(ws)
build.wait_for_completion(show_output=True)
```

```yml
# File: conda_run_env.yml
# Conda Training / Inference dependecies
name: shared_azml_py37
channels:
  - conda-forge
  - defaults
dependencies:
  - python=3.7
  - pip
  # Runtime Packages
  - matplotlib=3.1.*
  - numpy=1.18.*
  - pandas=0.25.*
  - scikit-learn=0.22.1
  - python-dateutil=2.8.0
  - pytz=2019.3
  - pyarrow
  - pip:
      - azureml-sdk[automl,explain]>=1.3.0
```