### PR TITLE
git security updates

### DIFF
--- a/base/cpu/intelmpi2018.3-ubuntu16.04/Dockerfile
+++ b/base/cpu/intelmpi2018.3-ubuntu16.04/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
     apt-get install -y \
     build-essential \
     bzip2 \
-    git=1:2.7.4-0ubuntu1.6 \
+    git=1:2.7.4-0ubuntu1.9 \
     wget \
     cpio && \
     apt-get clean -y && \

--- a/base/cpu/openmpi3.1.2-ubuntu16.04/Dockerfile
+++ b/base/cpu/openmpi3.1.2-ubuntu16.04/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
     apt-get install -y \
     build-essential \
     bzip2 \
-    git=1:2.7.4-0ubuntu1.6 \
+    git=1:2.7.4-0ubuntu1.9 \
     wget \
     cpio && \
     apt-get clean -y && \

--- a/base/cpu/openmpi3.1.2-ubuntu18.04/Dockerfile
+++ b/base/cpu/openmpi3.1.2-ubuntu18.04/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
     build-essential \
     bzip2=1.0.6-8.1ubuntu0.2 \
     libbz2-1.0=1.0.6-8.1ubuntu0.2 \
-    git=1:2.17.1-1ubuntu0.4 \
+    git=1:2.17.1-1ubuntu0.7 \
     wget \
     cpio \
     libsm6 \

--- a/base/gpu/intelmpi2018.3-cuda10.0-cudnn7-ubuntu16.04/Dockerfile
+++ b/base/gpu/intelmpi2018.3-cuda10.0-cudnn7-ubuntu16.04/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     apt-get install -y \
     build-essential \
     bzip2 \
-    git=1:2.7.4-0ubuntu1.6 \
+    git=1:2.7.4-0ubuntu1.9 \
     wget \
     cpio && \
     apt-get clean -y && \

--- a/base/gpu/intelmpi2018.3-cuda9.0-cudnn7-ubuntu16.04/Dockerfile
+++ b/base/gpu/intelmpi2018.3-cuda9.0-cudnn7-ubuntu16.04/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     apt-get install -y \
     build-essential \
     bzip2 \
-    git=1:2.7.4-0ubuntu1.6 \
+    git=1:2.7.4-0ubuntu1.9 \
     wget \
     cpio && \
     apt-get clean -y && \

--- a/base/gpu/openmpi3.1.2-cuda10.0-cudnn7-ubuntu16.04/Dockerfile
+++ b/base/gpu/openmpi3.1.2-cuda10.0-cudnn7-ubuntu16.04/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && \
     apt-get install -y \
     build-essential \
     bzip2 \
-    git=1:2.7.4-0ubuntu1.6 \
+    git=1:2.7.4-0ubuntu1.9 \
     wget \
     cpio && \
     apt-get clean -y && \

--- a/base/gpu/openmpi3.1.2-cuda10.0-cudnn7-ubuntu18.04/Dockerfile
+++ b/base/gpu/openmpi3.1.2-cuda10.0-cudnn7-ubuntu18.04/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && \
     bzip2=1.0.6-8.1ubuntu0.2 \
     libbz2-1.0=1.0.6-8.1ubuntu0.2 \
     systemd \
-    git=1:2.17.1-1ubuntu0.4 \
+    git=1:2.17.1-1ubuntu0.7 \
     wget \
     cpio \
     libsm6 \

--- a/base/gpu/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04/Dockerfile
+++ b/base/gpu/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && \
     bzip2=1.0.6-8.1ubuntu0.2 \
     libbz2-1.0=1.0.6-8.1ubuntu0.2 \
     systemd \
-    git=1:2.17.1-1ubuntu0.4 \
+    git=1:2.17.1-1ubuntu0.7 \
     wget \
     cpio \
     libsm6 \

--- a/base/gpu/openmpi3.1.2-cuda9.0-cudnn7-ubuntu16.04/Dockerfile
+++ b/base/gpu/openmpi3.1.2-cuda9.0-cudnn7-ubuntu16.04/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && \
     apt-get install -y \
     build-essential \
     bzip2 \
-    git=1:2.7.4-0ubuntu1.6 \
+    git=1:2.7.4-0ubuntu1.9 \
     wget \
     cpio && \
     apt-get clean -y && \


### PR DESCRIPTION
I was unable to build locally, due to outdated git packages:
`E: Version '1:2.7.4-0ubuntu1.6' for 'git' was not found`

After checking the issue, it turns out there are security patches applied.
https://launchpad.net/ubuntu/+source/git

For Xenial: 1:2.7.4-0ubuntu1.9  (2020-04-21)
For Bionic: 1:2.17.1-1ubuntu0.7 (2020-04-21)

I suppose the previous pinned versions have been removed (for security reasons)