### PR TITLE
Add an env var to support DeepSpeed ops.

### DIFF
--- a/base/gpu/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04/Dockerfile
+++ b/base/gpu/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04/Dockerfile
@@ -26,6 +26,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64
 ENV NCCL_DEBUG=INFO
 ENV HOROVOD_GPU_ALLREDUCE=NCCL
+ENV DS_BUILD_OPS=1
 
 # Install Common Dependencies
 RUN apt-get update && \


### PR DESCRIPTION
We would like to add this environment variable to base AML images so we can support ```pip install deepspeed``` and build the CUDA ops in DeepSpeed. 

For now, I am adding it to one of the base images' Dockerfile that I have tested extensively. It will be good to add to all others so we can support DeepSpeed in a generic way.