### PR TITLE
Add `git` to `openmpi4.1.0-ubuntu22.04` image

### DIFF
--- a/base/cpu/openmpi4.1.0-ubuntu22.04/Dockerfile
+++ b/base/cpu/openmpi4.1.0-ubuntu22.04/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
     openssh-client \
     openssh-server \
     curl \
+    git \
     #Adding packages to mitigate vulnerabilities
     libuuid1 \
     libblkid1 \


### PR DESCRIPTION
Closes #171 

Interestingly, the `openmpi4.1.0-ubuntu20.04` image has `git` included:

https://github.com/Azure/AzureML-Containers/blob/b34080a20b6ad8f5406288941dd9b4f7acc815b4/base/cpu/openmpi4.1.0-ubuntu20.04/Dockerfile#L34

However, when updating to `ubuntu22.04` the `git` dependency has been dropped. I propose to add it back